### PR TITLE
[Inspect command] Remove catch names and short name field if either aren't set

### DIFF
--- a/Custom Commands/inspect.py
+++ b/Custom Commands/inspect.py
@@ -1,4 +1,5 @@
 # Inspect command originally named "info" made by Nixter and converted from CarFigures to Ballsdex by me.
+# Thanks to arahman80 for making improvements to this command!
 # This command will send an embed with all of the information about the countryball (except for regime and economy).
 
     @app_commands.command()
@@ -15,18 +16,28 @@
         emoji = (
             self.bot.get_emoji(ball.emoji_id) or ""
         )  # Get emoji or an empty string if not found
+
+        description_lines = []
+
+        if ball.short_name:
+            description_lines.append(f"**⋄ Short Name:** {ball.short_name}")
+
+        if ball.catch_names:
+            catch_names_str = ", ".join(name.strip() for name in ball.catch_names.split(";"))
+            description_lines.append(f"**⋄ Catch Names:** {catch_names_str}")
+
+        description_lines.extend([
+            f"**⋄ Rarity:** {ball.rarity}",
+            f"**⋄ HP:** {ball.health}",
+            f"**⋄ ATK:** {ball.attack}",
+            f"**⋄ Capacity Name:** {ball.capacity_name}",
+            f"**⋄ Capacity Description:** {ball.capacity_description}",
+            f"**⋄ Credits:** {ball.credits}",
+        ])
+
         embed = discord.Embed(
             title=f"{emoji} {ball.country} Information:",
-            description=(
-                f"**⋄ Short Name:** {ball.short_name}\n"
-                f"**⋄ Catch Names:** {''.join(ball.catch_names or "None")}\n"
-                f"**⋄ Rarity:** {ball.rarity}\n"
-                f"**⋄ HP:** {ball.health}\n"
-                f"**⋄ ATK:** {ball.attack}\n"
-                f"**⋄ Capacity Name:** {ball.capacity_name}\n"
-                f"**⋄ Capacity Description:** {ball.capacity_description}\n"
-                f"**⋄ Credits:** {ball.credits}\n"
-            ),
+            description="\n".join(description_lines),
             color=discord.Colour.blurple()
         )
         await interaction.response.send_message(


### PR DESCRIPTION
Changes originally made by arahman80 (#3)

Removes catch names or short names field if either aren't set in the panel. Also slightly improves readabiliy.

No catch names or short name:
<img width="563" height="231" alt="image" src="https://github.com/user-attachments/assets/337c3c22-6658-4114-8ce4-c864629eb591" />

Puts catch names in commas for slightly better readability:
<img width="597" height="256" alt="image" src="https://github.com/user-attachments/assets/2a63e8dd-0ae6-4da6-b577-96da5be88de1" />
